### PR TITLE
feat: Enhanced Windows/Linux update reporting and reboot checking with inventory restructuring

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,81 @@
 
 ---
 
-#### This is a work-in-progress repo containing all the Ansible playbooks that I use for deploying and managing my home network environment.
+## Ansible Playbooks for Home Network Management
 
-#### These playbooks/roles could be broken, have bugs and issues, or are unfinished. Do not copy from these expecting them to work in your environment or at all. I will be writing documentation and adding comments to them when I have the majority of them completed to meet my needs.
+This repository contains a collection of Ansible playbooks and roles for deploying and managing a home network environment. The playbooks cover a wide range of tasks, including virtualization, containerization, storage, monitoring, and general Linux system management.
+
+> **Note:** This is a work-in-progress repository. Some playbooks/roles may be unfinished or have issues. Use at your own risk and adapt as needed for your environment.
 
 ---
 
-I have roles for creating, cloning and managing Proxmox VMs, and taking snapshots. Performing updates and configuration of Linux (Ubuntu/Debian based) systems: including installing packages, configuring SNMP, mounting network shares, installing Cockpit for web management and general purpose update, restart and shutdown commands. I also have roles for installing and managing Docker and Docker Swarm, container deployment and image pruning. And deployment of GlusterFS on linux systems.
+### Playbooks
+
+- `docker-prune.yaml` — Prune unused Docker images and containers
+- `docker-server-stack-configure.yaml` — Configure Docker server stack
+- `docker-swarm-server-stack-configure.yaml` — Configure Docker Swarm server stack
+- `game-server-stack-configure.yaml` — Configure game server stack
+- `kubernetes-cluster-stack-configure.yaml` — Configure Kubernetes cluster stack
+- `lxc-containers-configure.yaml` — Configure LXC containers
+- `patchman-install.yaml` — Install Patchman client
+- `proxmox-update.yaml` — Update Proxmox servers
+- `reboot.yaml` — Reboot target machines
+- `shutdown.yaml` — Shutdown target machines
+- `update-report-pve-clusters.yaml` — Generate update reports for Proxmox clusters
+- `update-report-vms-lxcs.yaml` — Generate update reports for VMs and LXCs
+- `vms-lxcs-update.yaml` — Update VMs and LXCs
+
+---
+
+### Roles
+
+#### Proxmox Management
+- `proxmox-create` — Create new Proxmox VMs
+- `proxmox-clone` — Clone existing Proxmox VMs
+- `proxmox-destroy` — Destroy Proxmox VMs
+- `proxmox-snapshot` — Manage Proxmox VM snapshots
+- `proxmox-vm-start` / `proxmox-vm-stop` — Start/stop VMs
+
+#### Docker & Container Management
+- `docker-install` — Install Docker
+- `docker-image-prune` — Prune Docker images
+- `docker-portainer-deploy` — Deploy Portainer
+- `docker-portainer-agent-deploy` — Deploy Portainer Agent
+- `docker-swarm-create` — Create Docker Swarm
+- `docker-swarm-manager-join` / `docker-swarm-worker-join` — Join Swarm as manager/worker
+
+#### Kubernetes & K3s
+- `k3s-master-deploy` — Deploy K3s master
+- `k3s-node-deploy` — Deploy K3s node
+- `k3s-prerequisites` — Prepare system for K3s
+- `kubernetes-portainer-agent-deploy` — Deploy Portainer Agent on Kubernetes
+
+#### Storage & Network
+- `glusterfs-configure` — Configure GlusterFS
+- `glusterfs-mount` — Mount GlusterFS volumes
+- `glusterfs-service` — Manage GlusterFS service
+- `network-share-mount` — Mount network shares
+
+#### System Management & Utilities
+- `base-packages` — Install base packages
+- `cc-amp-install` — Install AMP (Application Management Panel)
+- `cockpit-install` — Install Cockpit web management
+- `disable-motd-ubuntu` — Disable Ubuntu MOTD
+- `patchman-client-install` — Install Patchman client
+- `pause` — Pause execution
+- `pufferpanel-install` — Install PufferPanel
+- `qemu-guest-agent-install` — Install QEMU guest agent
+- `reboot` / `shutdown` — Reboot or shutdown systems
+- `reboot-required-check` — Check if reboot is required
+- `snmp-configure` — Configure SNMP
+- `update` — General update tasks
+- `update-report-aggregated-alert` / `update-report-single-alert` — Update reporting
+- `webmin-install` — Install Webmin
+
+---
+
+## Usage
+
+Refer to individual playbooks and roles for usage details/required environment variables.
 
 ---

--- a/physical-hosts-update.yaml
+++ b/physical-hosts-update.yaml
@@ -1,0 +1,7 @@
+- name: Update packages and OS on physical hosts
+  hosts: physical_hosts
+  roles:
+    - update
+    - reboot-required-check
+  vars:
+    reboot_status_discord_webhook_url: "{{ lookup('env', 'PHYSICAL_HOSTS_UPDATE_REPORT_DISCORD_WEBHOOK_URL') }}"

--- a/proxmox-update.yaml
+++ b/proxmox-update.yaml
@@ -1,5 +1,5 @@
 - name: Update packages on proxmox hypervisors
-  hosts: pve_core_cluster_01,pve_mini_cluster_01
+  hosts: proxmox_clusters
   roles:
     - update
     - reboot-required-check

--- a/roles/reboot-required-check/tasks/main.yml
+++ b/roles/reboot-required-check/tasks/main.yml
@@ -1,4 +1,4 @@
-- name: Check if reboot is required
+- name: Check if reboot is required [Linux]
   stat:
     path: /var/run/reboot-required
   register: reboot_check
@@ -6,20 +6,59 @@
   - ansible_facts['os_family'] == "Debian" or ansible_facts['os_family'] == "RedHat"
   - "'lxc' not in inventory_hostname | lower"
 
-- name: Set reboot_required fact
+- name: Check Windows reboot requirements [Windows]
+  ansible.windows.win_shell: |
+    # Check multiple registry keys and conditions that indicate a reboot is required
+    $rebootRequired = $false
+    
+    # Check Windows Update reboot flag
+    if (Get-ItemProperty "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\WindowsUpdate\Auto Update\RebootRequired" -ErrorAction SilentlyContinue) {
+        $rebootRequired = $true
+    }
+    
+    # Check Component Based Servicing reboot flag
+    if (Get-ChildItem "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Component Based Servicing\RebootPending" -ErrorAction SilentlyContinue) {
+        $rebootRequired = $true
+    }
+    
+    # Check Session Manager pending file operations
+    $sessionManager = Get-ItemProperty "HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager" -Name "PendingFileRenameOperations" -ErrorAction SilentlyContinue
+    if ($sessionManager) {
+        $rebootRequired = $true
+    }
+    
+    # Check SCCM Client reboot flag
+    try {
+        $sccmClient = Invoke-WmiMethod -Class CCM_ClientSDK -Name DetermineIfRebootPending -Namespace root\ccm\clientsdk -ErrorAction SilentlyContinue
+        if ($sccmClient -and ($sccmClient.RebootPending -or $sccmClient.IsHardRebootPending)) {
+            $rebootRequired = $true
+        }
+    } catch {}
+    
+    # Output result
+    Write-Output $rebootRequired
+  register: win_reboot_check
+  when: ansible_facts['os_family'] == "Windows"
+
+- name: Set reboot_required fact [Linux]
   set_fact:
     reboot_required: "{{ reboot_check.stat.exists | default(false) }}"
   when: 
   - ansible_facts['os_family'] == "Debian" or ansible_facts['os_family'] == "RedHat"
   - "'lxc' not in inventory_hostname | lower"
 
+- name: Set reboot_required fact [Windows]
+  set_fact:
+    reboot_required: "{{ win_reboot_check.stdout | trim | bool }}"
+  when: ansible_facts['os_family'] == "Windows"
+
 - name: Debug reboot status
   debug:
     msg: >
       Reboot is {{ 'REQUIRED' if reboot_required else 'not required' }}
   when: 
-  - ansible_facts['os_family'] == "Debian" or ansible_facts['os_family'] == "RedHat"
-  - "'lxc' not in inventory_hostname | lower"
+  - ansible_facts['os_family'] == "Debian" or ansible_facts['os_family'] == "RedHat" or ansible_facts['os_family'] == "Windows"
+  - "'lxc' not in inventory_hostname | lower or ansible_facts['os_family'] == 'Windows'"
 
 - name: Send Discord alert about reboot requirement
   uri:
@@ -43,5 +82,5 @@
   delay: 2
   delegate_to: localhost
   when: 
-  - ansible_facts['os_family'] == "Debian" or ansible_facts['os_family'] == "RedHat"
-  - "'lxc' not in inventory_hostname | lower"
+  - ansible_facts['os_family'] == "Debian" or ansible_facts['os_family'] == "RedHat" or ansible_facts['os_family'] == "Windows"
+  - "'lxc' not in inventory_hostname | lower or ansible_facts['os_family'] == 'Windows'"

--- a/roles/update-report-aggregated-alert/tasks/main.yml
+++ b/roles/update-report-aggregated-alert/tasks/main.yml
@@ -132,6 +132,7 @@
           footer:
             text: "Reported at {{ local_time_uk }}"
   run_once: true
+  delegate_to: localhost
 
 - name: Send Discord prompt with styled embed and interactive button via bot API
   uri:
@@ -156,3 +157,4 @@
               label: "Run Update Playbook"
               custom_id: "{{ custom_id }}"
   run_once: true
+  delegate_to: localhost

--- a/roles/update-report-aggregated-alert/tasks/main.yml
+++ b/roles/update-report-aggregated-alert/tasks/main.yml
@@ -69,7 +69,7 @@
       hostname: "{{ inventory_hostname }}"
       os_family: Windows
       upgradable: "{{ win_update_result.updates.values() | map(attribute='title') | list if win_update_result.updates is defined else [] }}"
-      security: "{{ win_update_result.updates.values() | selectattr('categories', 'intersect', ['Security Updates', 'Critical Updates', 'Definition Updates']) | map(attribute='title') | list if win_update_result.updates is defined else [] }}"
+      security: "{{ win_update_result.updates.values() | selectattr('categories', 'search', '(Security Updates|Critical Updates|Definition Updates)') | map(attribute='title') | list if win_update_result.updates is defined else [] }}"
   when: ansible_facts['os_family'] == "Windows"
 
 - name: Convert UTC time to UK local time (BST/GMT)

--- a/roles/update-report-aggregated-alert/tasks/main.yml
+++ b/roles/update-report-aggregated-alert/tasks/main.yml
@@ -1,27 +1,74 @@
-- name: Update apt cache (Debian/Ubuntu)
+- name: Update apt cache [Linux - Debian]
   ansible.builtin.apt:
     update_cache: yes
   when: ansible_facts['os_family'] == "Debian"
 
-- name: Get list of upgradable packages
+- name: Get list of upgradable packages [Debian]
   ansible.builtin.shell: apt list --upgradable 2>/dev/null | tail -n +2
   register: apt_upgradable_raw
   changed_when: false
   when: ansible_facts['os_family'] == "Debian"
 
-- name: Get list of security updates
+- name: Get list of security updates [Debian]
   ansible.builtin.shell: |
     unattended-upgrade --dry-run -d | grep "Checking: " | cut -d' ' -f2
   register: security_updates_raw
   changed_when: false
   when: ansible_facts['os_family'] == "Debian"
 
-- name: Parse lists into facts
+- name: Ensure dnf plugins are installed [RedHat]
+  ansible.builtin.package:
+    name: dnf-plugins-core
+    state: present
+  when: ansible_facts['os_family'] == "RedHat"
+
+- name: Get list of upgradable packages [RedHat]
+  ansible.builtin.shell: dnf check-update || true
+  register: dnf_upgradable_raw
+  changed_when: false
+  when: ansible_facts['os_family'] == "RedHat"
+
+- name: Get list of security updates [RedHat]
+  ansible.builtin.shell: dnf updateinfo list security all || true
+  register: dnf_security_raw
+  changed_when: false
+  when: ansible_facts['os_family'] == "RedHat"
+
+- name: Get Windows update list (search only)
+  ansible.windows.win_updates:
+    category_names:
+      - SecurityUpdates
+      - CriticalUpdates
+    state: searched
+  register: win_update_result
+  when: ansible_facts['os_family'] == "Windows"
+
+- name: Parse and collect report data [Debian]
   set_fact:
     report_data:
       hostname: "{{ inventory_hostname }}"
+      os_family: Debian
       upgradable: "{{ apt_upgradable_raw.stdout_lines | default([]) }}"
       security: "{{ security_updates_raw.stdout_lines | default([]) }}"
+  when: ansible_facts['os_family'] == "Debian"
+
+- name: Parse and collect report data [RedHat]
+  set_fact:
+    report_data:
+      hostname: "{{ inventory_hostname }}"
+      os_family: RedHat
+      upgradable: "{{ dnf_upgradable_raw.stdout_lines | default([]) }}"
+      security: "{{ dnf_security_raw.stdout_lines | default([]) }}"
+  when: ansible_facts['os_family'] == "RedHat"
+
+- name: Parse and collect report data [Windows]
+  set_fact:
+    report_data:
+      hostname: "{{ inventory_hostname }}"
+      os_family: Windows
+      upgradable: "{{ win_update_result.updates | map(attribute='title') | list }}"
+      security: "{{ win_update_result.updates | selectattr('categories', 'contains', 'SecurityUpdates') | map(attribute='title') | list }}"
+  when: ansible_facts['os_family'] == "Windows"
 
 - name: Convert UTC time to UK local time (BST/GMT)
   set_fact:

--- a/roles/update-report-aggregated-alert/tasks/main.yml
+++ b/roles/update-report-aggregated-alert/tasks/main.yml
@@ -43,11 +43,6 @@
   register: win_update_result
   when: ansible_facts['os_family'] == "Windows"
 
-- name: Debug Windows update structure
-  debug:
-    var: win_update_result
-  when: ansible_facts['os_family'] == "Windows"
-
 - name: Parse and collect report data [Debian]
   set_fact:
     report_data:
@@ -71,8 +66,8 @@
     report_data:
       hostname: "{{ inventory_hostname }}"
       os_family: Windows
-      upgradable: "{{ (win_update_result.updates | default([])) | map(attribute='title') | list }}"
-      security: "{{ (win_update_result.updates | default([])) | map(attribute='title') | list }}"
+      upgradable: "{{ (win_update_result.updates | default({})).values() | map(attribute='title') | list }}"
+      security: "{{ (win_update_result.updates | default({})).values() | selectattr('categories', 'contains', 'Security Updates') | map(attribute='title') | list }}"
   when: ansible_facts['os_family'] == "Windows"
 
 - name: Convert UTC time to UK local time (BST/GMT)
@@ -100,18 +95,30 @@
     embed_fields: "{{ embed_fields + [item_field] }}"
   vars:
     item_field:
-      name: "{{ item.hostname | default('Unknown Host') }} (📦 {{ item.upgradable | default([]) | length }}, ⚠️ {{ item.security | default([]) | length }})"
+      name: "{{ (item.hostname | default('Unknown Host'))[:100] }} (📦 {{ item.upgradable | default([]) | length }}, ⚠️ {{ item.security | default([]) | length }})"
       value: |
         **🔐 Security Updates:**
         {% if item.security | default([]) | length > 0 %}
-        {{ item.security | map('regex_replace', '^', '• ') | join(',  ') }}
+        {% set security_list = item.security | map('regex_replace', '^', '• ') | list %}
+        {% if security_list | join('  ') | length > 800 %}
+        {{ security_list[:5] | join('  ') }}
+        ... and {{ (item.security | length) - 5 }} more
+        {% else %}
+        {{ security_list | join('  ') }}
+        {% endif %}
         {% else %}
         ✅ No security updates
         {% endif %}
         
         **📦 All Upgradable Packages:**
         {% if item.upgradable | default([]) | length > 0 %}
-        {{ item.upgradable | map('regex_replace', '^', '• ') | join(',  ') }}
+        {% set upgradable_list = item.upgradable | map('regex_replace', '^', '• ') | list %}
+        {% if upgradable_list | join('  ') | length > 800 %}
+        {{ upgradable_list[:5] | join('  ') }}
+        ... and {{ (item.upgradable | length) - 5 }} more
+        {% else %}
+        {{ upgradable_list | join('  ') }}
+        {% endif %}
         {% else %}
         ✅ System is fully up-to-date
         {% endif %}
@@ -139,6 +146,11 @@
             text: "Reported at {{ local_time_uk }}"
   run_once: true
   delegate_to: localhost
+
+- name: Wait to avoid Discord rate limits
+  pause:
+    seconds: 2
+  run_once: true
 
 - name: Send Discord prompt with styled embed and interactive button via bot API
   uri:

--- a/roles/update-report-aggregated-alert/tasks/main.yml
+++ b/roles/update-report-aggregated-alert/tasks/main.yml
@@ -68,8 +68,8 @@
     report_data:
       hostname: "{{ inventory_hostname }}"
       os_family: Windows
-      upgradable: "{{ (win_update_result.updates | default({})).values() | map(attribute='title') | list }}"
-      security: "{{ (win_update_result.updates | default({})).values() | selectattr('categories', 'intersect', ['Security Updates', 'Critical Updates', 'Definition Updates']) | map(attribute='title') | list }}"
+      upgradable: "{{ win_update_result.updates.values() | map(attribute='title') | list if win_update_result.updates is defined else [] }}"
+      security: "{{ win_update_result.updates.values() | selectattr('categories', 'intersect', ['Security Updates', 'Critical Updates', 'Definition Updates']) | map(attribute='title') | list if win_update_result.updates is defined else [] }}"
   when: ansible_facts['os_family'] == "Windows"
 
 - name: Convert UTC time to UK local time (BST/GMT)

--- a/roles/update-report-aggregated-alert/tasks/main.yml
+++ b/roles/update-report-aggregated-alert/tasks/main.yml
@@ -37,8 +37,10 @@
 - name: Get Windows update list (search only)
   ansible.windows.win_updates:
     category_names:
-      - SecurityUpdates
-      - CriticalUpdates
+      - Security Updates
+      - Critical Updates
+      - Updates
+      - Definition Updates
     state: searched
   register: win_update_result
   when: ansible_facts['os_family'] == "Windows"
@@ -67,7 +69,7 @@
       hostname: "{{ inventory_hostname }}"
       os_family: Windows
       upgradable: "{{ (win_update_result.updates | default({})).values() | map(attribute='title') | list }}"
-      security: "{{ (win_update_result.updates | default({})).values() | selectattr('categories', 'contains', 'Security Updates') | map(attribute='title') | list }}"
+      security: "{{ (win_update_result.updates | default({})).values() | selectattr('categories', 'intersect', ['Security Updates', 'Critical Updates', 'Definition Updates']) | map(attribute='title') | list }}"
   when: ansible_facts['os_family'] == "Windows"
 
 - name: Convert UTC time to UK local time (BST/GMT)

--- a/roles/update-report-aggregated-alert/tasks/main.yml
+++ b/roles/update-report-aggregated-alert/tasks/main.yml
@@ -78,12 +78,13 @@
   set_fact:
     all_reports: >-
       {{
-        ansible_play_hosts_all
+        ansible_play_hosts
         | map('extract', hostvars)
         | selectattr('report_data', 'defined')
         | map(attribute='report_data')
         | list
       }}
+  run_once: true
 
 - name: Initialise embed_fields list
   set_fact:

--- a/roles/update-report-aggregated-alert/tasks/main.yml
+++ b/roles/update-report-aggregated-alert/tasks/main.yml
@@ -43,6 +43,11 @@
   register: win_update_result
   when: ansible_facts['os_family'] == "Windows"
 
+- name: Debug Windows update structure
+  debug:
+    var: win_update_result
+  when: ansible_facts['os_family'] == "Windows"
+
 - name: Parse and collect report data [Debian]
   set_fact:
     report_data:
@@ -66,8 +71,8 @@
     report_data:
       hostname: "{{ inventory_hostname }}"
       os_family: Windows
-      upgradable: "{{ win_update_result.updates | map(attribute='title') | list }}"
-      security: "{{ win_update_result.updates | selectattr('categories', 'contains', 'SecurityUpdates') | map(attribute='title') | list }}"
+      upgradable: "{{ (win_update_result.updates | default([])) | map(attribute='title') | list }}"
+      security: "{{ (win_update_result.updates | default([])) | map(attribute='title') | list }}"
   when: ansible_facts['os_family'] == "Windows"
 
 - name: Convert UTC time to UK local time (BST/GMT)

--- a/roles/update-report-single-alert/tasks/main.yml
+++ b/roles/update-report-single-alert/tasks/main.yml
@@ -132,3 +132,4 @@
               label: "Run Update Playbook"
               custom_id: "{{ custom_id }}"
   run_once: true
+  delegate_to: localhost

--- a/roles/update-report-single-alert/tasks/main.yml
+++ b/roles/update-report-single-alert/tasks/main.yml
@@ -69,7 +69,7 @@
       hostname: "{{ inventory_hostname }}"
       os_family: Windows
       upgradable: "{{ win_update_result.updates.values() | map(attribute='title') | list if win_update_result.updates is defined else [] }}"
-      security: "{{ win_update_result.updates.values() | selectattr('categories', 'intersect', ['Security Updates', 'Critical Updates', 'Definition Updates']) | map(attribute='title') | list if win_update_result.updates is defined else [] }}"
+      security: "{{ win_update_result.updates.values() | selectattr('categories', 'search', '(Security Updates|Critical Updates|Definition Updates)') | map(attribute='title') | list if win_update_result.updates is defined else [] }}"
   when: ansible_facts['os_family'] == "Windows"
 
 - name: Convert UTC time to UK local time (BST/GMT)

--- a/roles/update-report-single-alert/tasks/main.yml
+++ b/roles/update-report-single-alert/tasks/main.yml
@@ -37,8 +37,10 @@
 - name: Get Windows update list (search only)
   ansible.windows.win_updates:
     category_names:
-      - SecurityUpdates
-      - CriticalUpdates
+      - Security Updates
+      - Critical Updates
+      - Updates
+      - Definition Updates
     state: searched
   register: win_update_result
   when: ansible_facts['os_family'] == "Windows"
@@ -66,8 +68,8 @@
     report_data:
       hostname: "{{ inventory_hostname }}"
       os_family: Windows
-      upgradable: "{{ win_update_result.updates | map(attribute='title') | list }}"
-      security: "{{ win_update_result.updates | selectattr('categories', 'contains', 'SecurityUpdates') | map(attribute='title') | list }}"
+      upgradable: "{{ (win_update_result.updates | default({})).values() | map(attribute='title') | list }}"
+      security: "{{ (win_update_result.updates | default({})).values() | selectattr('categories', 'intersect', ['Security Updates', 'Critical Updates', 'Definition Updates']) | map(attribute='title') | list }}"
   when: ansible_facts['os_family'] == "Windows"
 
 - name: Convert UTC time to UK local time (BST/GMT)

--- a/roles/update-report-single-alert/tasks/main.yml
+++ b/roles/update-report-single-alert/tasks/main.yml
@@ -68,8 +68,8 @@
     report_data:
       hostname: "{{ inventory_hostname }}"
       os_family: Windows
-      upgradable: "{{ (win_update_result.updates | default({})).values() | map(attribute='title') | list }}"
-      security: "{{ (win_update_result.updates | default({})).values() | selectattr('categories', 'intersect', ['Security Updates', 'Critical Updates', 'Definition Updates']) | map(attribute='title') | list }}"
+      upgradable: "{{ win_update_result.updates.values() | map(attribute='title') | list if win_update_result.updates is defined else [] }}"
+      security: "{{ win_update_result.updates.values() | selectattr('categories', 'intersect', ['Security Updates', 'Critical Updates', 'Definition Updates']) | map(attribute='title') | list if win_update_result.updates is defined else [] }}"
   when: ansible_facts['os_family'] == "Windows"
 
 - name: Convert UTC time to UK local time (BST/GMT)

--- a/roles/update-report-single-alert/tasks/main.yml
+++ b/roles/update-report-single-alert/tasks/main.yml
@@ -89,15 +89,15 @@
           color: 16753920  # Orange-ish highlight (in decimal, 0xFFA500)
           fields:
             - name: "📦 Total Upgradable Packages"
-              value: "`{{ upgradable_packages | length }}`"
+              value: "`{{ report_data.upgradable | length }}`"
               inline: true
             - name: "⚠️ Security Updates"
-              value: "`{{ security_updates | length }}`"
+              value: "`{{ report_data.security | length }}`"
               inline: true
             - name: "🔸 Affected Packages"
               value: >-
-                {% if security_updates | length > 0 %}
-                  {{ security_updates | map('regex_replace', '^', '• ') | join('\n') }}
+                {% if report_data.security | length > 0 %}
+                  {{ report_data.security | map('regex_replace', '^', '• ') | join('\n') }}
                 {% else %}
                   No security updates found.
                 {% endif %}

--- a/roles/update-report-single-alert/tasks/main.yml
+++ b/roles/update-report-single-alert/tasks/main.yml
@@ -1,29 +1,78 @@
-- name: Update apt cache (Debian/Ubuntu)
+- name: Update apt cache [Linux - Debian]
   ansible.builtin.apt:
     update_cache: yes
   when: ansible_facts['os_family'] == "Debian"
 
-- name: Get list of upgradable packages
+- name: Get list of upgradable packages [Debian]
   ansible.builtin.shell: apt list --upgradable 2>/dev/null | tail -n +2
   register: apt_upgradable_raw
   changed_when: false
   when: ansible_facts['os_family'] == "Debian"
 
-- name: Get list of security updates
+- name: Get list of security updates [Debian]
   ansible.builtin.shell: |
     unattended-upgrade --dry-run -d | grep "Checking: " | cut -d' ' -f2
   register: security_updates_raw
   changed_when: false
   when: ansible_facts['os_family'] == "Debian"
 
-- name: Parse lists into facts
+- name: Ensure dnf plugins are installed [RedHat]
+  ansible.builtin.package:
+    name: dnf-plugins-core
+    state: present
+  when: ansible_facts['os_family'] == "RedHat"
+
+- name: Get list of upgradable packages [RedHat]
+  ansible.builtin.shell: dnf check-update || true
+  register: dnf_upgradable_raw
+  changed_when: false
+  when: ansible_facts['os_family'] == "RedHat"
+
+- name: Get list of security updates [RedHat]
+  ansible.builtin.shell: dnf updateinfo list security all || true
+  register: dnf_security_raw
+  changed_when: false
+  when: ansible_facts['os_family'] == "RedHat"
+
+- name: Get Windows update list (search only)
+  ansible.windows.win_updates:
+    category_names:
+      - SecurityUpdates
+      - CriticalUpdates
+    state: searched
+  register: win_update_result
+  when: ansible_facts['os_family'] == "Windows"
+
+- name: Parse and collect report data [Debian]
   set_fact:
-    upgradable_packages: "{{ apt_upgradable_raw.stdout_lines }}"
-    security_updates: "{{ security_updates_raw.stdout_lines }}"
+    report_data:
+      hostname: "{{ inventory_hostname }}"
+      os_family: Debian
+      upgradable: "{{ apt_upgradable_raw.stdout_lines | default([]) }}"
+      security: "{{ security_updates_raw.stdout_lines | default([]) }}"
+  when: ansible_facts['os_family'] == "Debian"
+
+- name: Parse and collect report data [RedHat]
+  set_fact:
+    report_data:
+      hostname: "{{ inventory_hostname }}"
+      os_family: RedHat
+      upgradable: "{{ dnf_upgradable_raw.stdout_lines | default([]) }}"
+      security: "{{ dnf_security_raw.stdout_lines | default([]) }}"
+  when: ansible_facts['os_family'] == "RedHat"
+
+- name: Parse and collect report data [Windows]
+  set_fact:
+    report_data:
+      hostname: "{{ inventory_hostname }}"
+      os_family: Windows
+      upgradable: "{{ win_update_result.updates | map(attribute='title') | list }}"
+      security: "{{ win_update_result.updates | selectattr('categories', 'contains', 'SecurityUpdates') | map(attribute='title') | list }}"
+  when: ansible_facts['os_family'] == "Windows"
 
 - name: Convert UTC time to UK local time (BST/GMT)
   set_fact:
-    local_time_uk: "{{ lookup('pipe', 'date -d \"' + ansible_date_time.iso8601 + '\" \"+%Y-%m-%d %H:%M:%S %Z\"') }}"
+    local_time_uk: "{{ lookup('pipe', 'date \"+%Y-%m-%d %H:%M:%S %Z\"') }}"
 
 - name: Send report to Discord using embed
   ansible.builtin.uri:

--- a/roles/update/tasks/main.yml
+++ b/roles/update/tasks/main.yml
@@ -31,7 +31,7 @@
 - name: Install all critical and security updates [Windows]
   ansible.windows.win_updates:
     category_names:
-      - CriticalUpdates
-      - SecurityUpdates
+      - Critical Updates
+      - Security Updates
     state: installed
   when: ansible_facts.os_family == "Windows"

--- a/roles/update/tasks/main.yml
+++ b/roles/update/tasks/main.yml
@@ -1,32 +1,37 @@
-  - name: Preliminary checks [Linux]
-    ansible.builtin.file:
-      path: /var/lib/apt/lists/
-      state: directory
-      mode: "0755"
-    when:
-      - ansible_facts.os_family == "Debian"
+- name: Preliminary checks [Linux - Debian]
+  ansible.builtin.file:
+    path: /var/lib/apt/lists/
+    state: directory
+    mode: "0755"
+  when: ansible_facts.os_family == "Debian"
 
-  - name: Enable Backports repository on Ubuntu Jammy Machines [Linux]
-    ansible.builtin.apt_repository:
-      repo: deb http://archive.ubuntu.com/ubuntu/ jammy-backports main restricted universe multiverse
-      state: present
-    when:
-      - ansible_distribution == 'Ubuntu' and ansible_distribution_version == '22.04'
+- name: Enable Backports repository on Ubuntu Jammy Machines [Linux]
+  ansible.builtin.apt_repository:
+    repo: deb http://archive.ubuntu.com/ubuntu/ jammy-backports main restricted universe multiverse
+    state: present
+  when:
+    - ansible_distribution == 'Ubuntu'
+    - ansible_distribution_version == '22.04'
 
-  - name: Install all updates [Linux]
-    ansible.builtin.apt:
-      update_cache: true
-      upgrade: dist
-      autoremove: true
-      autoclean: true
-    when:
-      - ansible_facts.os_family == "Debian"
+- name: Install all updates [Linux - Debian]
+  ansible.builtin.apt:
+    update_cache: true
+    upgrade: dist
+    autoremove: true
+    autoclean: true
+  when: ansible_facts.os_family == "Debian"
 
-  - name: Install all critical and security updates [Windows]
-    ansible.windows.win_updates:
-      category_names:
-        - CriticalUpdates
-        - SecurityUpdates
-      state: installed
-    when:
-      - ansible_facts.os_family == "Windows"
+- name: Install all updates [Linux - RedHat/CentOS/Alma/Rocky]
+  ansible.builtin.dnf:
+    name: '*'
+    state: latest
+    update_cache: true
+  when: ansible_facts.os_family == "RedHat"
+
+- name: Install all critical and security updates [Windows]
+  ansible.windows.win_updates:
+    category_names:
+      - CriticalUpdates
+      - SecurityUpdates
+    state: installed
+  when: ansible_facts.os_family == "Windows"

--- a/update-report-physical-hosts.yaml
+++ b/update-report-physical-hosts.yaml
@@ -1,0 +1,9 @@
+- name: Security update report and Discord notification
+  hosts: physical_hosts
+  roles:
+    - update-report-single-alert
+  vars:
+    update_report_discord_webhook_url: "{{ lookup('env', 'PHYSICAL_HOSTS_UPDATE_REPORT_DISCORD_WEBHOOK_URL') }}"
+    custom_id: "run_physical_hosts_update"
+    discord_bot_token: "{{ lookup('env', 'DISCORD_BOT_TOKEN') }}"
+    discord_channel_url: "{{ lookup('env', 'PHYSICAL_HOSTS_DISCORD_CHANNEL_URL') }}"

--- a/update-report-pve-clusters.yaml
+++ b/update-report-pve-clusters.yaml
@@ -1,5 +1,5 @@
 - name: Security update report and Discord notification
-  hosts: pve_core_cluster_01,pve_mini_cluster_01
+  hosts: proxmox_clusters
   roles:
     - update-report-single-alert
   vars:

--- a/update-report-vms-lxcs.yaml
+++ b/update-report-vms-lxcs.yaml
@@ -1,5 +1,5 @@
 - name: Security update report and Discord notification
-  hosts: lxc_containers,virtual_machines
+  hosts: virtual_infrastructure
   roles:
     - update-report-aggregated-alert
   vars:

--- a/vms-lxcs-update.yaml
+++ b/vms-lxcs-update.yaml
@@ -1,5 +1,5 @@
 - name: Update packages on VMs and Linux containers
-  hosts: lxc_containers,virtual_machines
+  hosts: virtual_infrastructure
   roles:
     - update
     - reboot-required-check

--- a/vms-lxcs-update.yaml
+++ b/vms-lxcs-update.yaml
@@ -1,4 +1,4 @@
-- name: Update packages on LXC containers
+- name: Update packages on VMs and Linux containers
   hosts: lxc_containers,virtual_machines
   roles:
     - update


### PR DESCRIPTION
This pull request includes significant improvements to the Ansible playbooks focusing on update reporting, reboot checking, and inventory management. The changes span 13 commits and affect multiple core components:

Key Features & Improvements:

Improved Windows update report data parsing with better error handling for undefined updates
Updated Windows security update parsing to use regex for accurate category matching
Added support for RedHat-based distributions and Windows hosts in update report roles
Enhanced Discord message formatting for better readability
Enhanced reboot checks for both Windows and Linux systems
Added additional conditions and improved clarity in reboot-required-check role

New Playbooks:

Added physical-hosts-update.yaml playbook for physical host update deployment
Created update-report-physical-hosts.yaml for dedicated physical host update reporting, using the same format as the existing