### PR TITLE
fix: add reboot handling and recheck for Windows updates when a reboot is required before more updates can be installed

### DIFF
--- a/roles/update/tasks/main.yml
+++ b/roles/update/tasks/main.yml
@@ -33,5 +33,29 @@
     category_names:
       - Critical Updates
       - Security Updates
+      - Updates
+      - Definition Updates
     state: installed
+  register: win_update_result
   when: ansible_facts.os_family == "Windows"
+
+- name: Reboot if required when windows updates stuck waiting on reboot before the rest will install [Windows]
+  ansible.windows.win_reboot:
+    msg: "Rebooting to complete updates"
+    pre_reboot_delay: 30
+    post_reboot_delay: 60
+  when:
+    - ansible_facts.os_family == "Windows"
+    - win_update_result.reboot_required | default(false)
+
+- name: Run Windows update check & install again after reboot [Windows]
+  ansible.windows.win_updates:
+    category_names:
+      - Critical Updates
+      - Security Updates
+      - Updates
+      - Definition Updates
+    state: installed
+  when:
+    - ansible_facts.os_family == "Windows"
+    - win_update_result.reboot_required | default(false)


### PR DESCRIPTION
Added logic to the update role, specifically for windows hosts, to automatically reboot hosts if required when trying to install updates and the update process is stuck due to a pending reboot for prior updates, and to re-check for additional updates post-reboot. This ensures all critical and security updates are applied without manual intervention and resolves issues where updates are blocked causing the playbook to hang or fail.